### PR TITLE
repositoryパターンを導入してSupabase依存を分離

### DIFF
--- a/app/api/games/[id]/like/route.ts
+++ b/app/api/games/[id]/like/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createRepositories } from '@/lib/repositories';
 import { NextResponse } from 'next/server';
 
 type Params = Promise<{ id: string }>;
@@ -6,105 +6,69 @@ type Params = Promise<{ id: string }>;
 // POST /api/games/[id]/like - Add a like
 export async function POST(request: Request, { params }: { params: Params }) {
   const { id: gameId } = await params;
-  const supabase = await createClient();
+  const { auth, users, games, likes } = await createRepositories();
 
   // Check authentication
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
+  const authUser = await auth.getUser();
+  if (!authUser) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   // Get user from our users table
-  const { data: dbUser } = await supabase
-    .from('users')
-    .select('id')
-    .eq('github_id', user.id)
-    .single();
-
+  const dbUser = await users.findByGithubId(authUser.id);
   if (!dbUser) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
 
   // Check if game exists
-  const { data: game } = await supabase
-    .from('games')
-    .select('id')
-    .eq('id', gameId)
-    .single();
-
-  if (!game) {
+  if (!(await games.exists(gameId))) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 });
   }
 
   // Check if already liked
-  const { data: existingLike } = await supabase
-    .from('likes')
-    .select('id')
-    .eq('user_id', dbUser.id)
-    .eq('game_id', gameId)
-    .single();
-
-  if (existingLike) {
+  if (await likes.exists(dbUser.id, gameId)) {
     return NextResponse.json({ error: 'Already liked' }, { status: 400 });
   }
 
-  // Create like
-  const { error } = await supabase.from('likes').insert({
-    user_id: dbUser.id,
-    game_id: gameId,
-  });
+  try {
+    // Create like
+    await likes.create(dbUser.id, gameId);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    // Get updated likes count
+    const count = await likes.countByGameId(gameId);
+    return NextResponse.json({ success: true, likes_count: count });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  // Get updated likes count
-  const { count } = await supabase
-    .from('likes')
-    .select('*', { count: 'exact', head: true })
-    .eq('game_id', gameId);
-
-  return NextResponse.json({ success: true, likes_count: count || 0 });
 }
 
 // DELETE /api/games/[id]/like - Remove a like
 export async function DELETE(request: Request, { params }: { params: Params }) {
   const { id: gameId } = await params;
-  const supabase = await createClient();
+  const { auth, users, likes } = await createRepositories();
 
   // Check authentication
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
+  const authUser = await auth.getUser();
+  if (!authUser) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   // Get user from our users table
-  const { data: dbUser } = await supabase
-    .from('users')
-    .select('id')
-    .eq('github_id', user.id)
-    .single();
-
+  const dbUser = await users.findByGithubId(authUser.id);
   if (!dbUser) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
 
-  // Delete like
-  const { error } = await supabase
-    .from('likes')
-    .delete()
-    .eq('user_id', dbUser.id)
-    .eq('game_id', gameId);
+  try {
+    // Delete like
+    await likes.delete(dbUser.id, gameId);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    // Get updated likes count
+    const count = await likes.countByGameId(gameId);
+    return NextResponse.json({ success: true, likes_count: count });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  // Get updated likes count
-  const { count } = await supabase
-    .from('likes')
-    .select('*', { count: 'exact', head: true })
-    .eq('game_id', gameId);
-
-  return NextResponse.json({ success: true, likes_count: count || 0 });
 }

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,126 +1,76 @@
-import { createClient } from '@/lib/supabase/server';
+import { createRepositories } from '@/lib/repositories';
 import { NextResponse } from 'next/server';
 
 // GET /api/games - Get all games with optional filtering
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const search = searchParams.get('search');
+  const search = searchParams.get('search') || undefined;
   const tags = searchParams.get('tags')?.split(',').filter(Boolean);
   const limit = parseInt(searchParams.get('limit') || '20');
   const offset = parseInt(searchParams.get('offset') || '0');
 
-  const supabase = await createClient();
+  const { auth, users, games, likes } = await createRepositories();
 
   // Get current user for is_liked field
-  const { data: { user } } = await supabase.auth.getUser();
+  const authUser = await auth.getUser();
   let currentUserId: string | null = null;
 
-  if (user) {
-    const { data: currentUser } = await supabase
-      .from('users')
-      .select('id')
-      .eq('github_id', user.id)
-      .single();
-    currentUserId = currentUser?.id || null;
+  if (authUser) {
+    const dbUser = await users.findByGithubId(authUser.id);
+    currentUserId = dbUser?.id || null;
   }
 
-  // Build the query
-  let query = supabase
-    .from('games')
-    .select(`
-      *,
-      user:users(id, username, avatar_url),
-      game_tags(tag:tags(*)),
-      likes(count)
-    `)
-    .order('created_at', { ascending: false })
-    .range(offset, offset + limit - 1);
+  try {
+    const gameList = await games.list({ search, tags, offset, limit });
 
-  // Apply search filter
-  if (search) {
-    query = query.or(`title.ilike.%${search}%,description.ilike.%${search}%`);
+    // Get likes status for current user
+    let userLikes: string[] = [];
+    if (currentUserId && gameList.length > 0) {
+      userLikes = await likes.findLikedGameIds(
+        currentUserId,
+        gameList.map(g => g.id),
+      );
+    }
+
+    const result = gameList.map(game => ({
+      ...game,
+      is_liked: userLikes.includes(game.id),
+    }));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  const { data: games, error } = await query;
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  // Filter by tags if provided (post-query filtering for now)
-  let filteredGames = games || [];
-  if (tags && tags.length > 0) {
-    filteredGames = filteredGames.filter(game => {
-      const gameTags = game.game_tags?.map((gt: { tag: { name: string } }) => gt.tag.name) || [];
-      return tags.some(tag => gameTags.includes(tag));
-    });
-  }
-
-  // Get likes status for current user
-  let userLikes: string[] = [];
-  if (currentUserId) {
-    const gameIds = filteredGames.map(g => g.id);
-    const { data: likesData } = await supabase
-      .from('likes')
-      .select('game_id')
-      .eq('user_id', currentUserId)
-      .in('game_id', gameIds);
-    userLikes = likesData?.map(l => l.game_id) || [];
-  }
-
-  // Transform the response
-  const transformedGames = filteredGames.map(game => ({
-    id: game.id,
-    title: game.title,
-    description: game.description,
-    screenshot_url: game.screenshot_url,
-    vercel_url: game.vercel_url,
-    github_url: game.github_url,
-    qiita_url: game.qiita_url,
-    created_at: game.created_at,
-    updated_at: game.updated_at,
-    user: game.user,
-    tags: game.game_tags?.map((gt: { tag: { id: string; name: string } }) => gt.tag) || [],
-    likes_count: game.likes?.[0]?.count || 0,
-    is_liked: userLikes.includes(game.id),
-  }));
-
-  return NextResponse.json(transformedGames);
 }
 
 // POST /api/games - Create a new game
 export async function POST(request: Request) {
-  const supabase = await createClient();
+  const { auth, users, games, tags } = await createRepositories();
 
   // Check authentication
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
+  const authUser = await auth.getUser();
+  if (!authUser) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   // Get user from our users table
-  const { data: dbUser } = await supabase
-    .from('users')
-    .select('id')
-    .eq('github_id', user.id)
-    .single();
-
+  const dbUser = await users.findByGithubId(authUser.id);
   if (!dbUser) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
 
   const body = await request.json();
-  const { title, description, screenshot_url, vercel_url, github_url, qiita_url, tags } = body;
+  const { title, description, screenshot_url, vercel_url, github_url, qiita_url, tags: tagNames } = body;
 
   // Validate required fields
   if (!title || !description || !screenshot_url || !vercel_url) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
-  // Create the game
-  const { data: game, error: gameError } = await supabase
-    .from('games')
-    .insert({
+  try {
+    // Create the game
+    const game = await games.create({
       user_id: dbUser.id,
       title,
       description,
@@ -128,62 +78,36 @@ export async function POST(request: Request) {
       vercel_url,
       github_url: github_url || null,
       qiita_url: qiita_url || null,
-    })
-    .select()
-    .single();
+    });
 
-  if (gameError) {
-    return NextResponse.json({ error: gameError.message }, { status: 500 });
-  }
+    // Handle tags
+    if (tagNames && tagNames.length > 0) {
+      const tagIds: string[] = [];
 
-  // Handle tags
-  if (tags && tags.length > 0) {
-    const tagIds: string[] = [];
+      for (const tagName of tagNames) {
+        let tag = await tags.findByName(tagName);
 
-    for (const tagName of tags) {
-      // Check if tag exists
-      let { data: existingTag } = await supabase
-        .from('tags')
-        .select('id')
-        .eq('name', tagName)
-        .single();
-
-      if (!existingTag) {
-        // Create new tag
-        const { data: newTag, error: tagError } = await supabase
-          .from('tags')
-          .insert({ name: tagName })
-          .select('id')
-          .single();
-
-        if (tagError) {
-          console.error('Error creating tag:', tagError);
-          continue;
+        if (!tag) {
+          try {
+            tag = await tags.create(tagName);
+          } catch (e) {
+            console.error('Error creating tag:', e);
+            continue;
+          }
         }
-        existingTag = newTag;
+
+        tagIds.push(tag.id);
       }
 
-      if (existingTag) {
-        tagIds.push(existingTag.id);
-      }
-    }
-
-    // Create game_tags entries
-    if (tagIds.length > 0) {
-      const gameTagsData = tagIds.map(tagId => ({
-        game_id: game.id,
-        tag_id: tagId,
-      }));
-
-      const { error: gameTagsError } = await supabase
-        .from('game_tags')
-        .insert(gameTagsData);
-
-      if (gameTagsError) {
-        console.error('Error creating game tags:', gameTagsError);
+      // Create game_tags entries
+      if (tagIds.length > 0) {
+        await tags.linkToGame(game.id, tagIds);
       }
     }
+
+    return NextResponse.json(game, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  return NextResponse.json(game, { status: 201 });
 }

--- a/app/api/users/[id]/games/route.ts
+++ b/app/api/users/[id]/games/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createRepositories } from '@/lib/repositories';
 import { NextResponse } from 'next/server';
 
 type Params = Promise<{ id: string }>;
@@ -10,65 +10,38 @@ export async function GET(request: Request, { params }: { params: Params }) {
   const limit = parseInt(searchParams.get('limit') || '20');
   const offset = parseInt(searchParams.get('offset') || '0');
 
-  const supabase = await createClient();
+  const { auth, users, games, likes } = await createRepositories();
 
   // Get current user for is_liked field
-  const { data: { user } } = await supabase.auth.getUser();
+  const authUser = await auth.getUser();
   let currentUserId: string | null = null;
 
-  if (user) {
-    const { data: currentUser } = await supabase
-      .from('users')
-      .select('id')
-      .eq('github_id', user.id)
-      .single();
-    currentUserId = currentUser?.id || null;
+  if (authUser) {
+    const dbUser = await users.findByGithubId(authUser.id);
+    currentUserId = dbUser?.id || null;
   }
 
-  const { data: games, error } = await supabase
-    .from('games')
-    .select(`
-      *,
-      user:users(id, username, avatar_url),
-      game_tags(tag:tags(*)),
-      likes(count)
-    `)
-    .eq('user_id', userId)
-    .order('created_at', { ascending: false })
-    .range(offset, offset + limit - 1);
+  try {
+    const gameList = await games.listByUserId(userId, { offset, limit });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    // Get likes status for current user
+    let userLikes: string[] = [];
+    if (currentUserId && gameList.length > 0) {
+      userLikes = await likes.findLikedGameIds(
+        currentUserId,
+        gameList.map(g => g.id),
+      );
+    }
+
+    // Transform the response
+    const result = gameList.map(game => ({
+      ...game,
+      is_liked: userLikes.includes(game.id),
+    }));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  // Get likes status for current user
-  let userLikes: string[] = [];
-  if (currentUserId && games && games.length > 0) {
-    const gameIds = games.map(g => g.id);
-    const { data: likesData } = await supabase
-      .from('likes')
-      .select('game_id')
-      .eq('user_id', currentUserId)
-      .in('game_id', gameIds);
-    userLikes = likesData?.map(l => l.game_id) || [];
-  }
-
-  // Transform the response
-  const transformedGames = (games || []).map(game => ({
-    id: game.id,
-    title: game.title,
-    description: game.description,
-    screenshot_url: game.screenshot_url,
-    vercel_url: game.vercel_url,
-    github_url: game.github_url,
-    qiita_url: game.qiita_url,
-    created_at: game.created_at,
-    updated_at: game.updated_at,
-    user: game.user,
-    tags: game.game_tags?.map((gt: { tag: { id: string; name: string } }) => gt.tag) || [],
-    likes_count: game.likes?.[0]?.count || 0,
-    is_liked: userLikes.includes(game.id),
-  }));
-
-  return NextResponse.json(transformedGames);
 }

--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -1,22 +1,17 @@
-import { createClient } from '@/lib/supabase/server';
+import { createRepositories } from '@/lib/repositories';
 import { NextResponse } from 'next/server';
 
 // GET /api/users/me - Get current authenticated user
 export async function GET() {
-  const supabase = await createClient();
+  const { auth, users } = await createRepositories();
 
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
+  const authUser = await auth.getUser();
+  if (!authUser) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { data: dbUser, error } = await supabase
-    .from('users')
-    .select('*')
-    .eq('github_id', user.id)
-    .single();
-
-  if (error || !dbUser) {
+  const dbUser = await users.findFullByGithubId(authUser.id);
+  if (!dbUser) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
 

--- a/lib/repositories/index.ts
+++ b/lib/repositories/index.ts
@@ -1,0 +1,47 @@
+import { createClient } from '@/lib/supabase/server';
+import {
+  IAuthRepository,
+  IUserRepository,
+  IGameRepository,
+  ITagRepository,
+  ILikeRepository,
+} from './interfaces';
+import {
+  SupabaseAuthRepository,
+  SupabaseUserRepository,
+  SupabaseGameRepository,
+  SupabaseTagRepository,
+  SupabaseLikeRepository,
+} from './supabase';
+
+export type Repositories = {
+  auth: IAuthRepository;
+  users: IUserRepository;
+  games: IGameRepository;
+  tags: ITagRepository;
+  likes: ILikeRepository;
+};
+
+export async function createRepositories(): Promise<Repositories> {
+  const supabase = await createClient();
+  return {
+    auth: new SupabaseAuthRepository(supabase),
+    users: new SupabaseUserRepository(supabase),
+    games: new SupabaseGameRepository(supabase),
+    tags: new SupabaseTagRepository(supabase),
+    likes: new SupabaseLikeRepository(supabase),
+  };
+}
+
+export type {
+  IAuthRepository,
+  IUserRepository,
+  IGameRepository,
+  ITagRepository,
+  ILikeRepository,
+  AuthUser,
+  GameDetail,
+  CreateGameInput,
+  UpdateGameInput,
+  UserProfile,
+} from './interfaces';

--- a/lib/repositories/interfaces.ts
+++ b/lib/repositories/interfaces.ts
@@ -1,0 +1,91 @@
+import { User, Game, Tag } from '@/types/database';
+
+// Auth types
+export type AuthUser = {
+  id: string;
+  userMetadata: {
+    userName?: string;
+    name?: string;
+    avatarUrl?: string;
+  };
+};
+
+// Game detail (without is_liked, which depends on auth context)
+export type GameDetail = {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  screenshot_url: string;
+  vercel_url: string;
+  github_url?: string;
+  qiita_url: string | null;
+  created_at: string;
+  updated_at: string;
+  user: Pick<User, 'id' | 'username' | 'avatar_url'>;
+  tags: Tag[];
+  likes_count: number;
+};
+
+export type CreateGameInput = {
+  user_id: string;
+  title: string;
+  description: string;
+  screenshot_url: string;
+  vercel_url: string;
+  github_url?: string | null;
+  qiita_url?: string | null;
+};
+
+export type UpdateGameInput = {
+  title?: string;
+  description?: string;
+  screenshot_url?: string;
+  vercel_url?: string;
+  github_url?: string;
+  qiita_url?: string | null;
+};
+
+export type UserProfile = Pick<User, 'id' | 'username' | 'avatar_url' | 'created_at'>;
+
+export interface IAuthRepository {
+  getUser(): Promise<AuthUser | null>;
+  exchangeCodeForSession(code: string): Promise<AuthUser | null>;
+}
+
+export interface IUserRepository {
+  findByGithubId(githubId: string): Promise<{ id: string } | null>;
+  findFullByGithubId(githubId: string): Promise<User | null>;
+  findById(id: string): Promise<UserProfile | null>;
+  create(data: { github_id: string; username: string; avatar_url: string | null }): Promise<void>;
+}
+
+export interface IGameRepository {
+  list(options: { search?: string; tags?: string[]; offset: number; limit: number }): Promise<GameDetail[]>;
+  findById(id: string): Promise<GameDetail | null>;
+  getOwnerId(id: string): Promise<string | null>;
+  exists(id: string): Promise<boolean>;
+  create(data: CreateGameInput): Promise<Game>;
+  update(id: string, data: UpdateGameInput): Promise<Game>;
+  delete(id: string): Promise<void>;
+  countByUserId(userId: string): Promise<number>;
+  listIdsByUserId(userId: string): Promise<string[]>;
+  listByUserId(userId: string, options: { offset: number; limit: number }): Promise<GameDetail[]>;
+}
+
+export interface ITagRepository {
+  list(options?: { query?: string; limit?: number }): Promise<Tag[]>;
+  findByName(name: string): Promise<{ id: string } | null>;
+  create(name: string): Promise<{ id: string }>;
+  linkToGame(gameId: string, tagIds: string[]): Promise<void>;
+  unlinkFromGame(gameId: string): Promise<void>;
+}
+
+export interface ILikeRepository {
+  create(userId: string, gameId: string): Promise<void>;
+  delete(userId: string, gameId: string): Promise<void>;
+  exists(userId: string, gameId: string): Promise<boolean>;
+  countByGameId(gameId: string): Promise<number>;
+  countByGameIds(gameIds: string[]): Promise<number>;
+  findLikedGameIds(userId: string, gameIds: string[]): Promise<string[]>;
+}

--- a/lib/repositories/supabase/auth.ts
+++ b/lib/repositories/supabase/auth.ts
@@ -1,0 +1,33 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database';
+import { IAuthRepository, AuthUser } from '../interfaces';
+
+export class SupabaseAuthRepository implements IAuthRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async getUser(): Promise<AuthUser | null> {
+    const { data: { user } } = await this.client.auth.getUser();
+    if (!user) return null;
+    return {
+      id: user.id,
+      userMetadata: {
+        userName: user.user_metadata?.user_name as string | undefined,
+        name: user.user_metadata?.name as string | undefined,
+        avatarUrl: user.user_metadata?.avatar_url as string | undefined,
+      },
+    };
+  }
+
+  async exchangeCodeForSession(code: string): Promise<AuthUser | null> {
+    const { data, error } = await this.client.auth.exchangeCodeForSession(code);
+    if (error || !data.user) return null;
+    return {
+      id: data.user.id,
+      userMetadata: {
+        userName: data.user.user_metadata?.user_name as string | undefined,
+        name: data.user.user_metadata?.name as string | undefined,
+        avatarUrl: data.user.user_metadata?.avatar_url as string | undefined,
+      },
+    };
+  }
+}

--- a/lib/repositories/supabase/games.ts
+++ b/lib/repositories/supabase/games.ts
@@ -1,0 +1,151 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database, Game, Tag } from '@/types/database';
+import { IGameRepository, GameDetail, CreateGameInput, UpdateGameInput } from '../interfaces';
+
+const GAME_WITH_RELATIONS_SELECT = `
+  *,
+  user:users(id, username, avatar_url),
+  game_tags(tag:tags(*)),
+  likes(count)
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformGame(raw: any): GameDetail {
+  return {
+    id: raw.id,
+    user_id: raw.user_id,
+    title: raw.title,
+    description: raw.description,
+    screenshot_url: raw.screenshot_url,
+    vercel_url: raw.vercel_url,
+    github_url: raw.github_url,
+    qiita_url: raw.qiita_url,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+    user: raw.user,
+    tags: raw.game_tags?.map((gt: { tag: Tag }) => gt.tag) || [],
+    likes_count: raw.likes?.[0]?.count || 0,
+  };
+}
+
+export class SupabaseGameRepository implements IGameRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async list(options: { search?: string; tags?: string[]; offset: number; limit: number }): Promise<GameDetail[]> {
+    let query = this.client
+      .from('games')
+      .select(GAME_WITH_RELATIONS_SELECT)
+      .order('created_at', { ascending: false })
+      .range(options.offset, options.offset + options.limit - 1);
+
+    if (options.search) {
+      query = query.or(`title.ilike.%${options.search}%,description.ilike.%${options.search}%`);
+    }
+
+    const { data: games, error } = await query;
+    if (error) throw error;
+
+    let result = (games || []).map(transformGame);
+
+    if (options.tags && options.tags.length > 0) {
+      result = result.filter(game => {
+        const gameTagNames = game.tags.map(t => t.name);
+        return options.tags!.some(tag => gameTagNames.includes(tag));
+      });
+    }
+
+    return result;
+  }
+
+  async findById(id: string): Promise<GameDetail | null> {
+    const { data, error } = await this.client
+      .from('games')
+      .select(GAME_WITH_RELATIONS_SELECT)
+      .eq('id', id)
+      .single();
+    if (error || !data) return null;
+    return transformGame(data);
+  }
+
+  async getOwnerId(id: string): Promise<string | null> {
+    const { data } = await this.client
+      .from('games')
+      .select('user_id')
+      .eq('id', id)
+      .single();
+    return data?.user_id ?? null;
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const { data } = await this.client
+      .from('games')
+      .select('id')
+      .eq('id', id)
+      .single();
+    return !!data;
+  }
+
+  async create(data: CreateGameInput): Promise<Game> {
+    const { data: game, error } = await this.client
+      .from('games')
+      .insert({
+        user_id: data.user_id,
+        title: data.title,
+        description: data.description,
+        screenshot_url: data.screenshot_url,
+        vercel_url: data.vercel_url,
+        github_url: data.github_url ?? undefined,
+        qiita_url: data.qiita_url,
+      })
+      .select()
+      .single();
+    if (error || !game) throw error ?? new Error('Failed to create game');
+    return game;
+  }
+
+  async update(id: string, data: UpdateGameInput): Promise<Game> {
+    const { data: game, error } = await this.client
+      .from('games')
+      .update(data)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error || !game) throw error ?? new Error('Failed to update game');
+    return game;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('games')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+  }
+
+  async countByUserId(userId: string): Promise<number> {
+    const { count } = await this.client
+      .from('games')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId);
+    return count ?? 0;
+  }
+
+  async listIdsByUserId(userId: string): Promise<string[]> {
+    const { data } = await this.client
+      .from('games')
+      .select('id')
+      .eq('user_id', userId);
+    return data?.map(g => g.id) ?? [];
+  }
+
+  async listByUserId(userId: string, options: { offset: number; limit: number }): Promise<GameDetail[]> {
+    const { data: games, error } = await this.client
+      .from('games')
+      .select(GAME_WITH_RELATIONS_SELECT)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .range(options.offset, options.offset + options.limit - 1);
+    if (error) throw error;
+    return (games || []).map(transformGame);
+  }
+}

--- a/lib/repositories/supabase/index.ts
+++ b/lib/repositories/supabase/index.ts
@@ -1,0 +1,5 @@
+export { SupabaseAuthRepository } from './auth';
+export { SupabaseUserRepository } from './users';
+export { SupabaseGameRepository } from './games';
+export { SupabaseTagRepository } from './tags';
+export { SupabaseLikeRepository } from './likes';

--- a/lib/repositories/supabase/likes.ts
+++ b/lib/repositories/supabase/likes.ts
@@ -1,0 +1,60 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database';
+import { ILikeRepository } from '../interfaces';
+
+export class SupabaseLikeRepository implements ILikeRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async create(userId: string, gameId: string): Promise<void> {
+    const { error } = await this.client
+      .from('likes')
+      .insert({ user_id: userId, game_id: gameId });
+    if (error) throw error;
+  }
+
+  async delete(userId: string, gameId: string): Promise<void> {
+    const { error } = await this.client
+      .from('likes')
+      .delete()
+      .eq('user_id', userId)
+      .eq('game_id', gameId);
+    if (error) throw error;
+  }
+
+  async exists(userId: string, gameId: string): Promise<boolean> {
+    const { data } = await this.client
+      .from('likes')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('game_id', gameId)
+      .single();
+    return !!data;
+  }
+
+  async countByGameId(gameId: string): Promise<number> {
+    const { count } = await this.client
+      .from('likes')
+      .select('*', { count: 'exact', head: true })
+      .eq('game_id', gameId);
+    return count ?? 0;
+  }
+
+  async countByGameIds(gameIds: string[]): Promise<number> {
+    if (gameIds.length === 0) return 0;
+    const { count } = await this.client
+      .from('likes')
+      .select('*', { count: 'exact', head: true })
+      .in('game_id', gameIds);
+    return count ?? 0;
+  }
+
+  async findLikedGameIds(userId: string, gameIds: string[]): Promise<string[]> {
+    if (gameIds.length === 0) return [];
+    const { data } = await this.client
+      .from('likes')
+      .select('game_id')
+      .eq('user_id', userId)
+      .in('game_id', gameIds);
+    return data?.map(l => l.game_id) ?? [];
+  }
+}

--- a/lib/repositories/supabase/tags.ts
+++ b/lib/repositories/supabase/tags.ts
@@ -1,0 +1,58 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database, Tag } from '@/types/database';
+import { ITagRepository } from '../interfaces';
+
+export class SupabaseTagRepository implements ITagRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async list(options?: { query?: string; limit?: number }): Promise<Tag[]> {
+    const limit = options?.limit ?? 50;
+    let query = this.client
+      .from('tags')
+      .select('*')
+      .order('usage_count', { ascending: false })
+      .limit(limit);
+
+    if (options?.query) {
+      query = query.ilike('name', `%${options.query}%`);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return data ?? [];
+  }
+
+  async findByName(name: string): Promise<{ id: string } | null> {
+    const { data } = await this.client
+      .from('tags')
+      .select('id')
+      .eq('name', name)
+      .single();
+    return data;
+  }
+
+  async create(name: string): Promise<{ id: string }> {
+    const { data, error } = await this.client
+      .from('tags')
+      .insert({ name })
+      .select('id')
+      .single();
+    if (error || !data) throw error ?? new Error('Failed to create tag');
+    return data;
+  }
+
+  async linkToGame(gameId: string, tagIds: string[]): Promise<void> {
+    if (tagIds.length === 0) return;
+    const rows = tagIds.map(tagId => ({ game_id: gameId, tag_id: tagId }));
+    const { error } = await this.client.from('game_tags').insert(rows);
+    if (error) throw error;
+  }
+
+  async unlinkFromGame(gameId: string): Promise<void> {
+    const { error } = await this.client
+      .from('game_tags')
+      .delete()
+      .eq('game_id', gameId);
+    if (error) throw error;
+  }
+}

--- a/lib/repositories/supabase/users.ts
+++ b/lib/repositories/supabase/users.ts
@@ -1,0 +1,39 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database, User } from '@/types/database';
+import { IUserRepository, UserProfile } from '../interfaces';
+
+export class SupabaseUserRepository implements IUserRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async findByGithubId(githubId: string): Promise<{ id: string } | null> {
+    const { data } = await this.client
+      .from('users')
+      .select('id')
+      .eq('github_id', githubId)
+      .single();
+    return data;
+  }
+
+  async findFullByGithubId(githubId: string): Promise<User | null> {
+    const { data } = await this.client
+      .from('users')
+      .select('*')
+      .eq('github_id', githubId)
+      .single();
+    return data;
+  }
+
+  async findById(id: string): Promise<UserProfile | null> {
+    const { data } = await this.client
+      .from('users')
+      .select('id, username, avatar_url, created_at')
+      .eq('id', id)
+      .single();
+    return data;
+  }
+
+  async create(data: { github_id: string; username: string; avatar_url: string | null }): Promise<void> {
+    const { error } = await this.client.from('users').insert(data);
+    if (error) throw error;
+  }
+}


### PR DESCRIPTION
APIルートからSupabase SDKの直接呼び出しを排除し、
interface経由でDB操作を行うよう変更。

- lib/repositories/interfaces.ts: 5つのrepository interface定義 (IAuthRepository, IUserRepository, IGameRepository, ITagRepository, ILikeRepository)
- lib/repositories/supabase/: 各interfaceのSupabase実装
- lib/repositories/index.ts: ファクトリ関数 createRepositories()
- app/api/ 配下の全8ルートをrepository経由に書き換え

DB実装を差し替える場合はsupabase/配下を別実装に置換するだけで対応可能。

https://claude.ai/code/session_01WCKkwiLXdexGQzVgkxMw3f